### PR TITLE
her-52-make-signup-login-and-create-trip-modal-less-translucent: Fixed modals for signups, logins and creating trips

### DIFF
--- a/components/create-trip-modal.tsx
+++ b/components/create-trip-modal.tsx
@@ -11,7 +11,7 @@ const inputClassName =
   "w-full rounded-2xl border border-white/55 bg-white/70 px-4 py-3 text-sm text-slate-800 shadow-inner outline-none ring-atlas-teal/25 placeholder:text-slate-400 focus:ring-2";
 
 const panelClassName =
-  "relative w-full max-w-md rounded-3xl border border-white/45 bg-white/40 p-7 shadow-[0_20px_50px_-12px_rgba(12,61,63,0.2)] backdrop-blur-md sm:p-8";
+  "relative w-full max-w-md rounded-3xl border border-white/80 bg-white/90 p-7 shadow-[0_20px_50px_-12px_rgba(12,61,63,0.2)] backdrop-blur-md sm:p-8";
 
 type CreateTripResponse = { trip: Trip };
 
@@ -115,7 +115,7 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-atlas-teal/30 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-atlas-teal/60 p-4 backdrop-blur-sm"
       role="presentation"
       onClick={onClose}
     >

--- a/components/join-trip-modal.tsx
+++ b/components/join-trip-modal.tsx
@@ -21,7 +21,7 @@ const inputClassName =
   "w-full rounded-2xl border border-white/55 bg-white/70 px-4 py-3 text-sm text-slate-800 shadow-inner outline-none ring-atlas-teal/25 placeholder:text-slate-400 focus:ring-2";
 
 const panelClassName =
-  "relative w-full max-w-md rounded-3xl border border-white/45 bg-white/40 p-7 shadow-[0_20px_50px_-12px_rgba(12,61,63,0.2)] backdrop-blur-md sm:p-8";
+  "relative w-full max-w-md rounded-3xl border border-white/80 bg-white/90 p-7 shadow-[0_20px_50px_-12px_rgba(12,61,63,0.2)] backdrop-blur-md sm:p-8";
 
 type JoinTripModalProps = {
   open: boolean;
@@ -193,7 +193,7 @@ export function JoinTripModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-atlas-teal/30 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-atlas-teal/60 p-4 backdrop-blur-sm"
       role="presentation"
       onClick={onClose}
     >

--- a/components/landing-create-card.tsx
+++ b/components/landing-create-card.tsx
@@ -21,8 +21,7 @@ export function LandingCreateCard({ cardClassName }: LandingCreateCardProps) {
           Create a New Trip
         </h2>
         <p className="mt-2 flex-1 text-sm leading-relaxed text-slate-600 sm:text-[0.95rem]">
-          Design your dream coastal route. Pick stops, invite buddies, and sync
-          your favorite soundtracks.
+          Coordinate your trip route. Pick stops, invite buddies, and organise your carpools.
         </p>
         <button
           type="button"


### PR DESCRIPTION
<img width="1512" height="825" alt="Screenshot 2026-05-21 at 3 37 08 pm" src="https://github.com/user-attachments/assets/79429f1c-2037-421e-bb6f-7cb371a87635" />
<img width="1512" height="825" alt="Screenshot 2026-05-21 at 3 37 43 pm" src="https://github.com/user-attachments/assets/f98c0f43-8385-4846-ae5c-b3d58583fdf8" />
<img width="1512" height="825" alt="Screenshot 2026-05-21 at 3 37 54 pm" src="https://github.com/user-attachments/assets/9a32c87b-79d2-4488-a6a3-112133eb17b5" />
